### PR TITLE
Ensure compatibility with non-Node.js runtimes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
+package-lock.json
 sandbox.js

--- a/package.json
+++ b/package.json
@@ -3,13 +3,15 @@
   "version": "1.0.0",
   "description": "Simple chunked decoder for newline delimited string",
   "main": "index.js",
-  "dependencies": {},
+  "dependencies": {
+    "string_decoder": "^1.3.0"
+  },
   "devDependencies": {
-    "standard": "^14.3.3",
-    "tape": "^5.0.0"
+    "brittle": "^3.3.2",
+    "standard": "^17.1.0"
   },
   "scripts": {
-    "test": "standard && tape test.js"
+    "test": "standard && brittle test.js"
   },
   "repository": {
     "type": "git",

--- a/test.js
+++ b/test.js
@@ -1,21 +1,19 @@
-const tape = require('tape')
-const NL = require('./')
+const test = require('brittle')
+const NL = require('.')
 
-tape('basic', function (t) {
+test('basic', function (t) {
   const nl = new NL()
 
-  t.same(nl.push('abe\nfest\ner\r\nsjov'), ['abe', 'fest', 'er'])
-  t.same(nl.end(), ['sjov'])
-  t.end()
+  t.alike(nl.push('abe\nfest\ner\r\nsjov'), ['abe', 'fest', 'er'])
+  t.alike(nl.end(), ['sjov'])
 })
 
-tape('basic chunked', function (t) {
+test('basic chunked', function (t) {
   const nl = new NL()
 
-  t.same(nl.push('abe\nfest\ner\r\nsjov'), ['abe', 'fest', 'er'])
-  t.same(nl.push('...'), [])
-  t.same(nl.push('!\r'), [])
-  t.same(nl.push('\n'), ['sjov...!'])
-  t.same(nl.end(), [])
-  t.end()
+  t.alike(nl.push('abe\nfest\ner\r\nsjov'), ['abe', 'fest', 'er'])
+  t.alike(nl.push('...'), [])
+  t.alike(nl.push('!\r'), [])
+  t.alike(nl.push('\n'), ['sjov...!'])
+  t.alike(nl.end(), [])
 })


### PR DESCRIPTION
Adds `string_decoder` as a dependency, which will continue resolving to the builtin module in Node.js, but will resolve to the npm version in runtimes that don't provide this builtin.

Also convert the tests to Brittle to make running the tests in other runtimes easier.